### PR TITLE
Fix T4 label weight

### DIFF
--- a/config.js
+++ b/config.js
@@ -157,7 +157,7 @@ const tiers = [
     labelStyle: {
       type: "radial",
       fontSize: 6,
-      fontWeight: "normal",
+      fontWeight: "bold",
       anchor: "middle",
       verticalAlign: "middle"
     },


### PR DESCRIPTION
## Summary
- make the tier 4 labels bold

## Testing
- `node -e "import('./config.js').then(m=>console.log('imported')).catch(e=>console.error(e))"`

------
https://chatgpt.com/codex/tasks/task_e_68531b9443848322a265d57f1680568f