### PR TITLE
Enable stroke for T1 tier

### DIFF
--- a/config.js
+++ b/config.js
@@ -69,7 +69,7 @@ const tiers = [
       startColor: "#ffffff",
       endColor: "#ffffff"
     },
-    stroke: { show: false },
+    stroke: { show: true, width: 1.0, color: "#000000" },
     showLabels: true,
     visible: true
   },


### PR DESCRIPTION
## Summary
- enable stroke for the Tier 1 ring in `config.js`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68532a13cec4832280e1f0ecf97c5ac5