### PR TITLE
Fix line artifact on inner rings

### DIFF
--- a/main.js
+++ b/main.js
@@ -155,12 +155,8 @@ function drawRing(svg, config, cx, cy) {
   path.setAttribute('d', ringPath(cx, cy, config.innerRadius, config.outerRadius));
   const fill = config.fill?.startColor || '#fff';
   path.setAttribute('fill', fill);
-  if (config.stroke?.show) {
-    path.setAttribute('stroke', config.stroke.color || '#000');
-    path.setAttribute('stroke-width', config.stroke.width || 0.25);
-  } else {
-    path.setAttribute('stroke', 'none');
-  }
+  // Stroke lines are drawn separately by drawBoundaries; avoid radial seams here
+  path.setAttribute('stroke', 'none');
   svg.appendChild(path);
 }
 


### PR DESCRIPTION
## Summary
- avoid radial seam at 12 o'clock on T0/T1 rings by omitting stroke in `drawRing`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68509980f13c8322969fcb7e8c87ca8f