### PR TITLE
Add overlay line options

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ Applied per-tier (not global)
 
 Optional radial overlay for global gradient (post-MVP)
 
+Global overlays also support `ringOutline` and `radialLines` types. These accept
+stroke `color`, optional `width` (defaulting to `renderOptions.strokeDefaults.wide`),
+and either a `radius` (for ring outlines) or an `angles` array (for radial lines).
+
 ✅ MVP Summary
 
 Fully functioning 7-tier wheel

--- a/main.js
+++ b/main.js
@@ -290,6 +290,39 @@ function drawOverlays(svg, overlays, cx, cy, defs) {
       path.setAttribute('pointer-events', 'none');
       svg.appendChild(path);
     }
+    else if (ov.type === 'ringOutline') {
+      const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+      circle.setAttribute('cx', cx);
+      circle.setAttribute('cy', cy);
+      circle.setAttribute('r', ov.radius);
+      circle.setAttribute('fill', 'none');
+      circle.setAttribute('pointer-events', 'none');
+
+      const strokeWidth = ov.width ?? (wheelConfig.renderOptions?.strokeDefaults?.wide || 1);
+
+      circle.setAttribute('stroke', ov.color || '#000');
+      circle.setAttribute('stroke-width', strokeWidth);
+
+      svg.appendChild(circle);
+    }
+    else if (ov.type === 'radialLines') {
+      const outer = ov.radius ?? Math.max(...wheelConfig.tiers.map(t => t.outerRadius));
+      const strokeWidth = ov.width ?? (wheelConfig.renderOptions?.strokeDefaults?.wide || 1);
+
+      (ov.angles || []).forEach(angle => {
+        const start = polarToCartesian(cx, cy, 0, angle);
+        const end = polarToCartesian(cx, cy, outer, angle);
+        const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+        line.setAttribute('x1', start.x);
+        line.setAttribute('y1', start.y);
+        line.setAttribute('x2', end.x);
+        line.setAttribute('y2', end.y);
+        line.setAttribute('stroke', ov.color || '#000');
+        line.setAttribute('stroke-width', strokeWidth);
+        line.setAttribute('pointer-events', 'none');
+        svg.appendChild(line);
+      });
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- add `ringOutline` and `radialLines` support in `drawOverlays`
- document overlay options in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685465cb10888322b645fda83f33d181