### PR TITLE
Improve radial stroke width logic

### DIFF
--- a/main.js
+++ b/main.js
@@ -222,7 +222,20 @@ function drawRadialTier(svg, config, tierIndex, cx, cy, rotationOffset, defs) {
     }
     path.setAttribute('fill', segmentFill);
     path.setAttribute('stroke', config.stroke?.show ? '#000' : 'none');
-    path.setAttribute('stroke-width', config.stroke?.normal || 0.25);
+
+    const normalWidth = config.stroke?.normal ??
+      (wheelConfig.renderOptions?.strokeDefaults?.normal || 0.25);
+    const wideWidth = config.stroke?.wide ?? config.stroke?.width ??
+      (wheelConfig.renderOptions?.strokeDefaults?.wide || normalWidth);
+
+    let strokeWidth = normalWidth;
+    if (typeof config.stroke?.every === 'number') {
+      const onPattern = (i % config.stroke.every === 0) &&
+        (config.stroke.includeFirst || i !== 0);
+      strokeWidth = onPattern ? wideWidth : normalWidth;
+    }
+
+    path.setAttribute('stroke-width', strokeWidth);
 
     svg.appendChild(path);
 


### PR DESCRIPTION
## Summary
- update drawRadialTier so strokes can alternate between normal and wide widths
- wide strokes occur based on `every` and `includeFirst`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854676979488322b7d3907eaeab1f65