### PR TITLE
Fix stroke joins for radial tiers

### DIFF
--- a/main.js
+++ b/main.js
@@ -236,6 +236,7 @@ function drawRadialTier(svg, config, tierIndex, cx, cy, rotationOffset, defs) {
     }
 
     path.setAttribute('stroke-width', strokeWidth);
+    path.setAttribute('stroke-linejoin', 'round');
 
     svg.appendChild(path);
 


### PR DESCRIPTION
## Summary
- fix radial tier path join style so stroke edges are rounded

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68547a22ce048322ab2be3b56bac6851