### PR TITLE
Support innerRadius in radialLines overlays

### DIFF
--- a/CONFIG_SPEC.md
+++ b/CONFIG_SPEC.md
@@ -73,3 +73,6 @@ const overlays = [
     to: "#00000033"
   }
 ];
+
+// `radialLines` overlays draw straight lines from `innerRadius` to `radius`
+// at each angle provided. `innerRadius` defaults to 0 if omitted.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Optional radial overlay for global gradient (post-MVP)
 
 Global overlays also support `ringOutline` and `radialLines` types. These accept
 stroke `color`, optional `width` (defaulting to `renderOptions.strokeDefaults.wide`),
-and either a `radius` (for ring outlines) or an `angles` array (for radial lines).
+and either a `radius` (for ring outlines) or an `angles` array (for radial lines). `radialLines` may also specify `innerRadius` to start lines away from the center.
 
 ✅ MVP Summary
 

--- a/config.js
+++ b/config.js
@@ -36,7 +36,7 @@ const renderOptions = {
   },
   fontDefaults: {
     fontFamily: "sans-serif"
-  }
+  },
 };
 
 /**
@@ -288,8 +288,16 @@ const overlays = [
     type: "radialGradient",
     radiusRange: [120, 500],
     from: "#ffffff00",
-    to: "#00000033"
-  }
+    to: "#00000033",
+  },
+  // Example radialLines overlay
+  // {
+  //   type: "radialLines",
+  //   angles: [0, 90, 180, 270],
+  //   radius: 500,
+  //   innerRadius: 120,
+  //   color: "#000000"
+  // }
 ];
 
 /**

--- a/main.js
+++ b/main.js
@@ -320,10 +320,11 @@ function drawOverlays(svg, overlays, cx, cy, defs) {
     }
     else if (ov.type === 'radialLines') {
       const outer = ov.radius ?? Math.max(...wheelConfig.tiers.map(t => t.outerRadius));
+      const inner = ov.innerRadius || 0;
       const strokeWidth = ov.width ?? (wheelConfig.renderOptions?.strokeDefaults?.wide || 1);
 
       (ov.angles || []).forEach(angle => {
-        const start = polarToCartesian(cx, cy, 0, angle);
+        const start = polarToCartesian(cx, cy, inner, angle);
         const end = polarToCartesian(cx, cy, outer, angle);
         const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
         line.setAttribute('x1', start.x);


### PR DESCRIPTION
## Summary
- allow radialLines overlays to start from their configured inner radius
- document `innerRadius` in README and CONFIG_SPEC
- show example radialLines overlay in `config.js`

## Testing
- `node config.js >/dev/null && echo OK`

------
https://chatgpt.com/codex/tasks/task_e_68547ad470b883229a686bb68ec9f34d