### PR TITLE
Fix overlays syntax

### DIFF
--- a/config.js
+++ b/config.js
@@ -288,17 +288,12 @@ const overlays = [
     type: "radialGradient",
     radiusRange: [120, 500],
     from: "#ffffff00",
-    to: "#00000033",
-  },
-  // Example radialLines overlay
-  // {
-  //   type: "radialLines",
-  //   angles: [0, 90, 180, 270],
-  //   radius: 500,
-  //   innerRadius: 120,
-  //   color: "#000000"
-  // }
+    to: "#00000033"
+  }
 ];
+
+// `radialLines` overlays draw straight lines from `innerRadius` to `radius`
+// at each angle provided. `innerRadius` defaults to 0 if omitted.
 
 /**
  * EXPORT FULL CONFIG


### PR DESCRIPTION
## Summary
- clean up example overlay markers in `config.js`
- match overlay section with the specification

## Testing
- `node -c config.js`

------
https://chatgpt.com/codex/tasks/task_e_68547d1921b08322b1ba92b3ce502bc5