### PR TITLE
Fix first radial slice rendering

### DIFF
--- a/main.js
+++ b/main.js
@@ -188,6 +188,7 @@ function drawRadialTier(svg, config, tierIndex, cx, cy, rotationOffset, defs) {
       'A', outer, outer, 0, largeArc, 1, p2.x, p2.y,
       'L', p3.x, p3.y,
       'A', inner, inner, 0, largeArc, 0, p4.x, p4.y,
+      'L', p1.x, p1.y,
       'Z'
     ].join(' ');
 
@@ -237,6 +238,7 @@ function drawRadialTier(svg, config, tierIndex, cx, cy, rotationOffset, defs) {
 
     path.setAttribute('stroke-width', strokeWidth);
     path.setAttribute('stroke-linejoin', 'round');
+    path.setAttribute('stroke-linecap', 'round');
 
     svg.appendChild(path);
 


### PR DESCRIPTION
## Summary
- draw explicit closing line for radial slices
- smooth radial stroke caps so vertical lines display

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853373b2a808322a6b6e74c24269a6e