### PR TITLE
Add radial boundary lines

### DIFF
--- a/config.js
+++ b/config.js
@@ -289,6 +289,13 @@ const overlays = [
     radiusRange: [120, 500],
     from: "#ffffff00",
     to: "#00000033"
+  },
+  {
+    type: "radialLines",
+    angles: t4DivisionAngles,
+    innerRadius: tiers[5].innerRadius,
+    radius: tiers[6].outerRadius,
+    color: "#000000"
   }
 ];
 

--- a/main.js
+++ b/main.js
@@ -222,7 +222,8 @@ function drawRadialTier(svg, config, tierIndex, cx, cy, rotationOffset, defs) {
       segmentFill = config.fill.colors[i];
     }
     path.setAttribute('fill', segmentFill);
-    path.setAttribute('stroke', config.stroke?.show ? '#000' : 'none');
+    // Slice outlines are drawn separately; remove stroke from individual paths
+    path.setAttribute('stroke', 'none');
 
     const normalWidth = config.stroke?.normal ??
       (wheelConfig.renderOptions?.strokeDefaults?.normal || 0.25);


### PR DESCRIPTION
## Summary
- disable strokes on radial slices
- overlay radial lines using T4 angles

## Testing
- `node --check config.js`
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_685488f38e2c8322b0c5185f201413ec