### PR TITLE
Handle rotated radial overlays

### DIFF
--- a/CONFIG_SPEC.md
+++ b/CONFIG_SPEC.md
@@ -76,3 +76,4 @@ const overlays = [
 
 // `radialLines` overlays draw straight lines from `innerRadius` to `radius`
 // at each angle provided. `innerRadius` defaults to 0 if omitted.
+// Angles are offset by the wheel's current rotation so lines stay aligned.

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Optional radial overlay for global gradient (post-MVP)
 Global overlays also support `ringOutline` and `radialLines` types. These accept
 stroke `color`, optional `width` (defaulting to `renderOptions.strokeDefaults.wide`),
 and either a `radius` (for ring outlines) or an `angles` array (for radial lines). `radialLines` may also specify `innerRadius` to start lines away from the center.
+`radialLines` overlays automatically track the wheel's rotation; each angle is offset by the current rotation value.
 
 ✅ MVP Summary
 

--- a/main.js
+++ b/main.js
@@ -25,7 +25,7 @@ function renderWheel() {
 
   // Draw any global overlays after tiers
   if (Array.isArray(wheelConfig.overlays)) {
-    drawOverlays(svg, wheelConfig.overlays, centerX, centerY, defs);
+    drawOverlays(svg, wheelConfig.overlays, centerX, centerY, defs, currentRotation);
   }
 
   // Draw tier boundary outlines last so they appear on top
@@ -270,7 +270,7 @@ function drawRadialTier(svg, config, tierIndex, cx, cy, rotationOffset, defs) {
   }
 }
 
-function drawOverlays(svg, overlays, cx, cy, defs) {
+function drawOverlays(svg, overlays, cx, cy, defs, rotationOffset = 0) {
   overlays.forEach((ov, idx) => {
     if (ov.type === 'radialGradient') {
       const gradId = `ov-grad-${idx}`;
@@ -325,10 +325,12 @@ function drawOverlays(svg, overlays, cx, cy, defs) {
       const outer = ov.radius ?? Math.max(...wheelConfig.tiers.map(t => t.outerRadius));
       const inner = ov.innerRadius || 0;
       const strokeWidth = ov.width ?? (wheelConfig.renderOptions?.strokeDefaults?.wide || 1);
+      const rotationAngle = (rotationOffset * 360) / wheelConfig.globalDivisionCount;
 
       (ov.angles || []).forEach(angle => {
-        const start = polarToCartesian(cx, cy, inner, angle);
-        const end = polarToCartesian(cx, cy, outer, angle);
+        const rotated = angle + rotationAngle;
+        const start = polarToCartesian(cx, cy, inner, rotated);
+        const end = polarToCartesian(cx, cy, outer, rotated);
         const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
         line.setAttribute('x1', start.x);
         line.setAttribute('y1', start.y);


### PR DESCRIPTION
## Summary
- rotate overlay lines with the wheel rotation
- document rotation tracking for radial line overlays

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685875eb360083228253b1eea133852c