### PR TITLE
Add overlay visibility flag

### DIFF
--- a/CONFIG_SPEC.md
+++ b/CONFIG_SPEC.md
@@ -67,6 +67,7 @@ const renderOptions = {
  */
 const overlays = [
   {
+    visible: true,
     type: "radialGradient",
     radiusRange: [120, 500],
     from: "#ffffff00",
@@ -77,3 +78,5 @@ const overlays = [
 // `radialLines` overlays draw straight lines from `innerRadius` to `radius`
 // at each angle provided. `innerRadius` defaults to 0 if omitted.
 // Angles are offset by the wheel's current rotation so lines stay aligned.
+// Set `visible: false` on any overlay object to hide it without removing the
+// configuration entry.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Global overlays also support `ringOutline` and `radialLines` types. These accept
 stroke `color`, optional `width` (defaulting to `renderOptions.strokeDefaults.wide`),
 and either a `radius` (for ring outlines) or an `angles` array (for radial lines). `radialLines` may also specify `innerRadius` to start lines away from the center.
 `radialLines` overlays automatically track the wheel's rotation; each angle is offset by the current rotation value.
+All overlay objects accept an optional `visible` flag that defaults to `true`. Set it to `false` to temporarily hide that overlay.
 
 ✅ MVP Summary
 

--- a/config.js
+++ b/config.js
@@ -285,12 +285,14 @@ const tiers = [
  */
 const overlays = [
   {
+    visible: true,
     type: "radialGradient",
     radiusRange: [120, 500],
     from: "#ffffff00",
     to: "#00000033"
      },
   {
+    visible: true,
     type: "radialLines",
     angles: [0],
     innerRadius: 120,

--- a/main.js
+++ b/main.js
@@ -272,6 +272,7 @@ function drawRadialTier(svg, config, tierIndex, cx, cy, rotationOffset, defs) {
 
 function drawOverlays(svg, overlays, cx, cy, defs, rotationOffset = 0) {
   overlays.forEach((ov, idx) => {
+    if (ov.visible === false) return;
     if (ov.type === 'radialGradient') {
       const gradId = `ov-grad-${idx}`;
       const grad = document.createElementNS('http://www.w3.org/2000/svg', 'radialGradient');


### PR DESCRIPTION
## Summary
- allow hiding overlays by adding a `visible` field in overlay config
- skip drawing overlays when `visible` is `false`
- document new flag in README and CONFIG_SPEC

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685b100d0a6c8322aff554db4a3c596d