### PR TITLE
Add overlay rendering to radial tiers

### DIFF
--- a/main.js
+++ b/main.js
@@ -268,6 +268,23 @@ function drawRadialTier(svg, config, tierIndex, cx, cy, rotationOffset, defs) {
       svg.appendChild(text);
     }
   }
+
+  // Apply optional overlay effect across the entire tier
+  if (config.overlay && config.overlay.visible !== false) {
+    const overlayPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    overlayPath.setAttribute('d', ringPath(cx, cy, config.innerRadius, config.outerRadius));
+    overlayPath.setAttribute('fill', config.overlay.color || (config.overlay.mode === 'shade' ? '#000' : '#fff'));
+    overlayPath.setAttribute('fill-opacity', config.overlay.strength ?? 0.25);
+    overlayPath.setAttribute('pointer-events', 'none');
+
+    if (config.overlay.mode === 'shade') {
+      overlayPath.style.mixBlendMode = 'multiply';
+    } else if (config.overlay.mode === 'tint') {
+      overlayPath.style.mixBlendMode = 'screen';
+    }
+
+    svg.appendChild(overlayPath);
+  }
 }
 
 function drawOverlays(svg, overlays, cx, cy, defs, rotationOffset = 0) {


### PR DESCRIPTION
## Summary
- support `overlay` blocks on tiers
- render tint/shade overlays using blend modes

## Testing
- `node -e "require('./main.js')"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685b1f003d908322be13123fedc77a73