### PR TITLE
Add debug guide rendering controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,12 @@ rotationStep: Defines snap angle per rotate button (based on 132 divisions)
 
 rotationButtons: Configurable step list, e.g. -20, -3, +3, +20
 
-debugRenderOutlines: Enables outline/stroke rendering for debug
+debugRenderOutlines: When `true`, `main.js` draws thin circle outlines at each tier
+boundary for alignment checks. Disable to hide these debug rings.
 
-debugGuides: Enables internal radial guides for dev use
+debugGuides: When `true`, `main.js` renders radial markers for every
+`globalDivisionCount` slice. These lines rotate with the wheel to show
+current division alignment.
 
 strokeDefaults: Defines normal and wide line width globally
 

--- a/main.js
+++ b/main.js
@@ -28,8 +28,15 @@ function renderWheel() {
     drawOverlays(svg, wheelConfig.overlays, centerX, centerY, defs, currentRotation);
   }
 
-  // Draw tier boundary outlines last so they appear on top
-  drawBoundaries(svg, wheelConfig.tiers, centerX, centerY);
+  // Debug guides for radial divisions
+  if (wheelConfig.renderOptions?.debugGuides) {
+    drawDebugGuides(svg, centerX, centerY, currentRotation);
+  }
+
+  // Draw tier boundary outlines last so they appear on top if enabled
+  if (wheelConfig.renderOptions?.debugRenderOutlines) {
+    drawBoundaries(svg, wheelConfig.tiers, centerX, centerY);
+  }
 }
 
 // === ROTATION BUTTONS ===
@@ -366,6 +373,26 @@ function drawBoundaries(svg, tiers, cx, cy) {
 
     svg.appendChild(circle);
   });
+}
+
+function drawDebugGuides(svg, cx, cy, rotationOffset = 0) {
+  const outer = Math.max(...wheelConfig.tiers.map(t => t.outerRadius));
+  const rotationAngle = (rotationOffset * 360) / wheelConfig.globalDivisionCount;
+
+  for (let i = 0; i < wheelConfig.globalDivisionCount; i++) {
+    const angle = (i / wheelConfig.globalDivisionCount) * 360 + rotationAngle;
+    const start = polarToCartesian(cx, cy, 0, angle);
+    const end = polarToCartesian(cx, cy, outer, angle);
+    const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    line.setAttribute('x1', start.x);
+    line.setAttribute('y1', start.y);
+    line.setAttribute('x2', end.x);
+    line.setAttribute('y2', end.y);
+    line.setAttribute('stroke', '#888');
+    line.setAttribute('stroke-width', wheelConfig.renderOptions?.strokeDefaults?.normal || 0.25);
+    line.setAttribute('pointer-events', 'none');
+    svg.appendChild(line);
+  }
 }
 
 function ringPath(cx, cy, inner, outer) {


### PR DESCRIPTION
## Summary
- render radial division guides and boundary outlines only when enabled
- document debug flags in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b209bbaf0832285869c1d7e105315