### PR TITLE
Use normal stroke width for outer tiers

### DIFF
--- a/CONFIG_SPEC.md
+++ b/CONFIG_SPEC.md
@@ -43,6 +43,8 @@ const tiers = [
   },
 
   // T1 - T6 remain as before, to be updated next...
+  // T5 and T6 now draw thin boundaries using `strokeDefaults.normal` on every
+  // segment.
 ];
 
 /**

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ includeFirst: Ensures first line is always drawn
 
 No stroke logic is inferred — full visual control
 
+T5 and T6 use the `normal` stroke width across all 132 boundaries.
+
 🎛️ Fill Modes
 
 solid: Flat fill

--- a/config.js
+++ b/config.js
@@ -236,11 +236,7 @@ const tiers = [
     },
     stroke: {
       show: true,
-      width: renderOptions.strokeDefaults.wide,
-      normal: 0.25,
-      wide: 1.0,
-      every: 4,
-      includeFirst: true
+      width: renderOptions.strokeDefaults.normal
     },
     showLabels: true,
     visible: true
@@ -269,11 +265,7 @@ const tiers = [
     },
     stroke: {
       show: true,
-      width: renderOptions.strokeDefaults.wide,
-      normal: 0.25,
-      wide: 1.0,
-      every: 4,
-      includeFirst: true
+      width: renderOptions.strokeDefaults.normal
     },
     showLabels: true,
     visible: true


### PR DESCRIPTION
## Summary
- use the normal stroke width for tiers 5 and 6
- document updated stroke width for outer tiers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c6595996c832294b4d98424440b6e