### PR TITLE
Clean up unused rotation options

### DIFF
--- a/CONFIG_SPEC.md
+++ b/CONFIG_SPEC.md
@@ -51,8 +51,6 @@ const tiers = [
  * GLOBAL OPTIONS
  */
 const renderOptions = {
-  rotationStep: 30,
-  rotationEnabled: true,
   debugGuides: false,
   debugRenderOutlines: true,
   strokeDefaults: {

--- a/README.md
+++ b/README.md
@@ -14,15 +14,11 @@ Rendering Order: T0 → T6
 
 Draw Logic: Center-out, non-overlapping SVG segments
 
-Rotation: Optional; user-controlled with multiple step options
+Rotation: Optional; user-controlled via buttons
 
 🔧 Global Config Controls
 
 globalDivisionCount: Total radial slices (132)
-
-rotationStep: Defines snap angle per rotate button (based on 132 divisions)
-
-rotationButtons: Configurable step list, e.g. -20, -3, +3, +20
 
 debugRenderOutlines: When `true`, `main.js` draws thin circle outlines at each tier
 boundary for alignment checks. Disable to hide these debug rings.
@@ -129,11 +125,9 @@ Each T6 state maps 1:1 with existing 132 segment structure
 
 Rotation is optional, included in MVP
 
-Rotation step values can be any integer from 1 to 132
-
-Suggested default: -20, -3, +3, +20
-
-All tiers (except T0–T2) rotate together
+Rotation buttons in `index.html` increment or decrement the wheel in
+fixed steps. All tiers (except T0–T2) rotate together
+and track the current rotation angle.
 
 T0–T2 have rotationLocked: true
 

--- a/config.js
+++ b/config.js
@@ -26,8 +26,6 @@ const t4Weights = Array(33).fill(4);
 const t4DivisionAngles = weightsToAngles(t4Weights);
 
 const renderOptions = {
-  rotationStep: 30,
-  rotationEnabled: true,
   debugGuides: false,
   debugRenderOutlines: true,
   strokeDefaults: {


### PR DESCRIPTION
## Summary
- remove `rotationStep` and `rotationEnabled` since nothing references them
- document current rotation controls in README
- keep debug options in `renderOptions`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d6263da988322bd63e6e6e12bc3b8