### PR TITLE
Refactor grid lines into overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ All labels can be toggled with showLabels
 
 Per-tier stroke object:
 
-show: Toggles line rendering
+show: Toggles ring boundary rendering
 
 normal, wide: Thickness settings
 
@@ -70,9 +70,10 @@ every: Applies wide stroke every N divisions
 
 includeFirst: Ensures first line is always drawn
 
-No stroke logic is inferred — full visual control
-
-T5 and T6 use the `normal` stroke width across all 132 boundaries.
+Segment wedges no longer use strokes for their radial boundaries. Bold
+dividers are drawn via the `radialLines` overlay using the new
+`t4SegmentAngles` list. The faint spreadsheet grid still comes from a
+separate overlay.
 
 🎛️ Fill Modes
 
@@ -146,6 +147,9 @@ stroke `color`, optional `width` (defaulting to `renderOptions.strokeDefaults.wi
 and either a `radius` (for ring outlines) or an `angles` array (for radial lines). `radialLines` may also specify `innerRadius` to start lines away from the center.
 `radialLines` overlays automatically track the wheel's rotation; each angle is offset by the current rotation value.
 All overlay objects accept an optional `visible` flag that defaults to `true`. Set it to `false` to temporarily hide that overlay.
+
+The default configuration uses `radialLines` with `t4SegmentAngles` to draw
+bold separators from tier T4 out to T6.
 
 ✅ MVP Summary
 

--- a/config.js
+++ b/config.js
@@ -25,6 +25,9 @@ const t4Weights = Array(33).fill(4);
 // so deeper tiers can share the exact boundary positions.
 const t4DivisionAngles = weightsToAngles(t4Weights);
 
+// Angles for each of the 33 primary T4 segments
+const t4SegmentAngles = t4DivisionAngles.filter((_, i) => i % 4 === 0);
+
 const renderOptions = {
   debugGuides: false,
   debugRenderOutlines: true,
@@ -284,7 +287,7 @@ const overlays = [
   {
     visible: true,
     type: "radialLines",
-    angles: [0],
+    angles: t4SegmentAngles,
     innerRadius: 120,
     radius: 500,
     width: renderOptions.strokeDefaults.wide-.3,

--- a/main.js
+++ b/main.js
@@ -229,23 +229,8 @@ function drawRadialTier(svg, config, tierIndex, cx, cy, rotationOffset, defs) {
       segmentFill = config.fill.colors[i];
     }
     path.setAttribute('fill', segmentFill);
-    path.setAttribute('stroke', config.stroke?.show ? '#000' : 'none');
-
-    const normalWidth = config.stroke?.normal ??
-      (wheelConfig.renderOptions?.strokeDefaults?.normal || 0.25);
-    const wideWidth = config.stroke?.wide ?? config.stroke?.width ??
-      (wheelConfig.renderOptions?.strokeDefaults?.wide || normalWidth);
-
-    let strokeWidth = normalWidth;
-    if (typeof config.stroke?.every === 'number') {
-      const onPattern = (i % config.stroke.every === 0) &&
-        (config.stroke.includeFirst || i !== 0);
-      strokeWidth = onPattern ? wideWidth : normalWidth;
-    }
-
-    path.setAttribute('stroke-width', strokeWidth);
-    path.setAttribute('stroke-linejoin', 'round');
-    path.setAttribute('stroke-linecap', 'round');
+    // Cell boundaries are now drawn via overlays, not per-path strokes
+    path.setAttribute('stroke', 'none');
 
     svg.appendChild(path);
 


### PR DESCRIPTION
## Summary
- drop stroke usage from radial wedge drawing
- add `t4SegmentAngles` config to control overlay separators
- draw bold radial lines with overlay logic
- document new approach in the README

## Testing
- `npm test` *(fails: unable to fetch from npm)*

------
https://chatgpt.com/codex/tasks/task_e_685d75feac508322b24e292b7bf055f9