### PR TITLE
Update wheel stroke widths and overlays

### DIFF
--- a/config.js
+++ b/config.js
@@ -253,7 +253,7 @@ const tiers = [
     },
     stroke: {
       show: true,
-      width: renderOptions.strokeDefaults.normal
+      width: renderOptions.strokeDefaults.wide
     },
     showLabels: true,
     visible: true
@@ -282,7 +282,7 @@ const tiers = [
     },
     stroke: {
       show: true,
-      width: renderOptions.strokeDefaults.normal
+      width: renderOptions.strokeDefaults.wide
     },
     showLabels: true,
     visible: true
@@ -340,6 +340,20 @@ const overlays = [
     radius: tiers[6].outerRadius,
     width: renderOptions.strokeDefaults.normal,
     color: "#000"
+  },
+  {
+    visible: true,
+    type: 'ringOutline',
+    radius: 250,
+    width: renderOptions.strokeDefaults.wide,
+    color: '#000'
+  },
+  {
+    visible: true,
+    type: 'ringOutline',
+    radius: 500,
+    width: renderOptions.strokeDefaults.wide,
+    color: '#000'
   }
 ];
 


### PR DESCRIPTION
## Summary
- use wide stroke widths for Tier 5 and Tier 6
- add ring-outline overlays so outlines show without debug mode

## Testing
- `npm test` *(fails: no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_685ef2477b6883229694d97c9145ce96