### PR TITLE
Align slice gradients with wedge centerlines

### DIFF
--- a/main.js
+++ b/main.js
@@ -210,10 +210,14 @@ function drawRadialTier(svg, config, tierIndex, cx, cy, rotationOffset, defs) {
         const gradId = `grad-${tierIndex}-${i}`;
         const grad = document.createElementNS('http://www.w3.org/2000/svg', 'linearGradient');
         grad.setAttribute('id', gradId);
-        grad.setAttribute('x1', '0%');
-        grad.setAttribute('y1', '0%');
-        grad.setAttribute('x2', '0%');
-        grad.setAttribute('y2', '100%');
+        const midAngle = (startAngle + endAngle) / 2;
+        const innerPt = polarToCartesian(cx, cy, inner, midAngle);
+        const outerPt = polarToCartesian(cx, cy, outer, midAngle);
+        grad.setAttribute('gradientUnits', 'userSpaceOnUse');
+        grad.setAttribute('x1', innerPt.x);
+        grad.setAttribute('y1', innerPt.y);
+        grad.setAttribute('x2', outerPt.x);
+        grad.setAttribute('y2', outerPt.y);
         const stop1 = document.createElementNS('http://www.w3.org/2000/svg', 'stop');
         stop1.setAttribute('offset', '0%');
         stop1.setAttribute('stop-color', pair[0]);


### PR DESCRIPTION
## Summary
- orient manual gradients along the midpoint of each wedge

## Testing
- `npm test` *(fails: npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686014c91f1c83228c4be0aa11a89eea